### PR TITLE
Allow reconnecting to devices that have already been paired

### DIFF
--- a/Blazor.Bluetooth/BluetoothRemoteGATTServer.cs
+++ b/Blazor.Bluetooth/BluetoothRemoteGATTServer.cs
@@ -28,8 +28,7 @@ namespace Blazor.Bluetooth
         {
             try
             {
-                await BluetoothNavigator.JsRuntime.InvokeVoidAsync("ble.connectCurrentDevice");
-                var currentDevice = await BluetoothNavigator.JsRuntime.InvokeAsync<Device>("ble.getCurrentDevice");
+                var currentDevice = await BluetoothNavigator.JsRuntime.InvokeAsync<Device>("ble.connectDevice", InternalDeviceUuid);
                 InternalConnected = currentDevice.Gatt.Connected;
             }
             catch (JSException ex)
@@ -42,8 +41,7 @@ namespace Blazor.Bluetooth
         {
             try
             {
-                await BluetoothNavigator.JsRuntime.InvokeVoidAsync("ble.disconnectCurrentDevice");
-                var currentDevice = await BluetoothNavigator.JsRuntime.InvokeAsync<Device>("ble.getCurrentDevice");
+                var currentDevice = await BluetoothNavigator.JsRuntime.InvokeAsync<Device>("ble.disconnectDevice", InternalDeviceUuid);
                 InternalConnected = currentDevice.Gatt.Connected;
             }
             catch (JSException ex)

--- a/Blazor.Bluetooth/wwwroot/JSInterop.js
+++ b/Blazor.Bluetooth/wwwroot/JSInterop.js
@@ -290,9 +290,9 @@ window.ble.connectCurrentDevice = async () => {
 
 window.ble.connectDevice = async (deviceId) => {
     var device = getPairedBluetoothDeviceById(deviceId);
-    await device.gatt.connect();
 
     if (device !== null) {
+        await device.gatt.connect();
         return convertDevice(device);
     }
     else {
@@ -307,9 +307,9 @@ window.ble.disconnectCurrentDevice = async () => {
 
 window.ble.disconnectDevice = async (deviceId) => {
     var device = getPairedBluetoothDeviceById(deviceId);
-    await device.gatt.disconnect();
 
     if (device !== null) {
+        await device.gatt.disconnect();
         return convertDevice(device);
     }
     else {

--- a/Blazor.Bluetooth/wwwroot/JSInterop.js
+++ b/Blazor.Bluetooth/wwwroot/JSInterop.js
@@ -359,6 +359,12 @@ window.ble.getDevices = async () => {
         var devices = await navigator.bluetooth.getDevices();
 
         devices.forEach((device) => {
+            var alreadyPariedDevice = getPairedBluetoothDeviceById(device.id);
+            if (alreadyPariedDevice != null) {
+                var indexToRemove = PairedBluetoothDevices.findIndex(x => x.id == device.id);
+                PairedBluetoothDevices.splice(indexToRemove, 1);
+            }
+
             PairedBluetoothDevices.push(device);
         });
 

--- a/Blazor.Bluetooth/wwwroot/JSInterop.js
+++ b/Blazor.Bluetooth/wwwroot/JSInterop.js
@@ -283,14 +283,38 @@ window.ble.getCurrentDevice = () => {
     }
 }
 
-window.ble.connectCurrentDevice = async() => {
+window.ble.connectCurrentDevice = async () => {
     var device = window.ble.currentDevice;
     await device.gatt.connect();
+}
+
+window.ble.connectDevice = async (deviceId) => {
+    var device = getPairedBluetoothDeviceById(deviceId);
+    await device.gatt.connect();
+
+    if (device !== null) {
+        return convertDevice(device);
+    }
+    else {
+        return null;
+    }
 }
 
 window.ble.disconnectCurrentDevice = async () => {
     var device = window.ble.currentDevice;
     await device.gatt.disconnect();
+}
+
+window.ble.disconnectDevice = async (deviceId) => {
+    var device = getPairedBluetoothDeviceById(deviceId);
+    await device.gatt.disconnect();
+
+    if (device !== null) {
+        return convertDevice(device);
+    }
+    else {
+        return null;
+    }
 }
 
 window.ble.referringDevice = () => {
@@ -333,6 +357,11 @@ window.ble.getDevices = async () => {
         throw 'Get devices is not supporting';
     } else {
         var devices = await navigator.bluetooth.getDevices();
+
+        devices.forEach((device) => {
+            PairedBluetoothDevices.push(device);
+        });
+
         return devices.map(x => convertDevice(x));
     }
 }
@@ -379,7 +408,7 @@ async function onAvailabilityChanged() {
 }
 
 window.ble.addBluetoothAvailabilityHandler = (bluetoothAvailabilityHandler) => {
-    
+
     if (bluetoothAvailabilityHandler !== null) {
 
         BluetoothAvailabilityHandler = bluetoothAvailabilityHandler;


### PR DESCRIPTION
As it currently stands you can only connect to the currentDevice set after selecting a device through requestDevice. This prohibits using getDevices to reconnect to an already paired device since getDevices does not set currentDevice and may return multiple devices with which you may want to connect to. 

This change makes connect use the deviceId instead and so does not rely on currentDevice being set. This allows you to use getDevices to obtain a list of already paired devices and connect to the one you want.